### PR TITLE
Some small improvements

### DIFF
--- a/document.md
+++ b/document.md
@@ -5,7 +5,7 @@
 | iDKDoJa | 903i Series (?) |  |
 | RTPlayer (Ring Tone Authoring Tool) | NEC uPD9993 (?) | By rewriting the metadata vers to 0300, unplayable mld may become playable. |
 | MCP-MA7 | YAMAHA MA-7 | By rewriting the metadata vers to 0300, unplayable mld may become playable. |
-| MidRadio Player (Ver.7) | YAMAHA S-YXG20 (?) | Most mld files cannot be played. |
+| MidRadio Player (Ver.7) | YAMAHA MA-5 | Most mld files cannot be played. |
 | MidRadio Player (Ver.~6) | YAMAHA S-YXG50 (?) | Most mld files cannot be played. |
 | PsmPlayer | Windows MIDI | |
 

--- a/get_mld_metadata.py
+++ b/get_mld_metadata.py
@@ -86,7 +86,7 @@ def main(file_path):
     # format
     match metadata["data_type_major"]:
         case 1:
-            metadata["data_type_major"] = f"{metadata['data_type_major']} (ringtorn)"
+            metadata["data_type_major"] = f"{metadata['data_type_major']} (ringtone)"
         case 2:
             metadata["data_type_major"] = f"{metadata['data_type_major']} (music)"
         case _:
@@ -118,7 +118,7 @@ def main(file_path):
     if ("version" in metadata):
         integer_part = int(metadata["version"][0:2])
         decimal_part = int(metadata["version"][2:4])
-        metadata["version"] += f" (MFi{integer_part}.{decimal_part})"
+        metadata["version"] += f" (MFi{integer_part}.{decimal_part:02})"
         
     if ("date" in metadata):
         metadata["date"] = metadata["date"].strftime('%Y/%m/%d')


### PR DESCRIPTION
- Correct typo ('ringtorn' to 'ringtone')
- Improve MFi version notation
  - It needs to be easily distinguishable between MFi3.01 and MFi3.10
  - Here's a sample file of MFi3.01 and MFi3.10: [MFi3_sample.zip](https://github.com/kagekiyo7/mld-tools/files/15140346/MFi3_sample.zip)
