### PR TITLE
Small improvement about document

### DIFF
--- a/document.md
+++ b/document.md
@@ -5,7 +5,7 @@
 | iDKDoJa | 903i Series (?) |  |
 | RTPlayer (Ring Tone Authoring Tool) | NEC uPD9993 (?) | By rewriting the metadata vers to 0300, unplayable mld may become playable. |
 | MCP-MA7 | YAMAHA MA-7 | By rewriting the metadata vers to 0300, unplayable mld may become playable. |
-| MidRadio Player | YAMAHA MA-5 | Most mld files cannot be played. |
+| MidRadio Player | YAMAHA MA-5 | Most mld files cannot be played.<br>Information source: [info.txt of MidRadio Ver.7](https://href.li/?https://download.music-eclub.com/mrplayer/win/v7/info.txt), [info.txt of MidRadio Ver.6](https://href.li/?https://download.music-eclub.com/mrplayer/win/v6/info.txt) |
 | PsmPlayer | Windows MIDI | |
 
 (others: TiMidity++, MLDUtil, Awave Studio)


### PR DESCRIPTION
It seems MidRadio 6 also uses MA-5 sound source because it plays [Technopolis ringtone from N900i](http://onj3.andrelouis.com/phonetones/unzipped/NEC/N900i/n900i_91.mld) correctly